### PR TITLE
changed maven repos to https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ tasks.withType(JavaCompile) {
 }
 
 repositories {
-     maven { url "http://dl.bintray.com/pegasystems/fringeutils" }
-     maven { url "http://repo.maven.apache.org/maven2" }
+     maven { url "https://dl.bintray.com/pegasystems/fringeutils" }
+     maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 dependencies {


### PR DESCRIPTION
Build was broken 

501 HTTPS Required. 
Use https://repo.maven.apache.org/maven2/
More information at https://links.sonatype.com/central/501-https-required

sanzv@pega.com